### PR TITLE
Adding the additional fastcgi_*timeout with the provided .Values.web.…

### DIFF
--- a/ipeer/Chart.yaml
+++ b/ipeer/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.11
+version: 0.1.12
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/ipeer/templates/nginx-configmap.yaml
+++ b/ipeer/templates/nginx-configmap.yaml
@@ -34,7 +34,8 @@ data:
         location ~ \.php$ {
           include fastcgi_params;
           fastcgi_index index.php;
-          fastcgi_read_timeout {{ .Values.web.timeout }};
+          fastcgi_read_timeout {{ .Values.web.timeout }}s;
+          fastcgi_send_timeout {{ .Values.web.timeout }}s;
           fastcgi_param REQUEST_METHOD $request_method;
           fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
           fastcgi_pass 127.0.0.1:9000;


### PR DESCRIPTION

Adding the additional fastcgi_*timeout with the provided .Values.web.timeout also resolved the error.

Note, without the s, NGINX will throw an error because it expects a valid time format, and seconds need to be explicitly defined.

Note2: (per John's suggestion) the documentation says "It should be noted that this timeout cannot usually exceed 75 seconds."

Note2: updated Chart ver to 0.1.12
