### PR TITLE
Move saml ingress definitions to values file (instead of in the chart)

### DIFF
--- a/ipeer-ubc-cwl-login/Chart.yaml
+++ b/ipeer-ubc-cwl-login/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.2
+version: 0.2.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/ipeer-ubc-cwl-login/templates/deployment.yaml
+++ b/ipeer-ubc-cwl-login/templates/deployment.yaml
@@ -14,7 +14,6 @@ replicas: {{ .Values.replicaCount }}
   template:
     metadata:
       annotations:
-        rollme: {{ now | quote }}
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/ipeer-ubc-cwl-login/templates/ingress.yaml
+++ b/ipeer-ubc-cwl-login/templates/ingress.yaml
@@ -43,28 +43,13 @@ spec:
       http:
         paths:
           {{- range .paths }}
-          - path: /
-            pathType: Prefix
+          - path: {{ .path }}
+            pathType: {{ .type | default "Prefix" }}
             backend:
               service:
-                name: {{ $fullName }}
+                name: {{ .service | default $fullName  }}
                 port:
-                  number: {{ $svcPort }}
-          {{- $samlServiceName := default (printf "%s-cwl-oneloginsaml" $fullName) $.Values.ingress.samlServiceName }}
-          - path: /public/saml/auth.php
-            pathType: ImplementationSpecific
-            backend:
-              service:
-                name: {{ $samlServiceName }}
-                port:
-                  number: 80
-          - path: /public/saml/logout.php
-            pathType: ImplementationSpecific
-            backend:
-              service:
-                name: {{ $samlServiceName }}
-                port:
-                  number: 80
+                  number: {{ .port | default $svcPort }}
           {{- end }}
     {{- end }}
   {{- end }}

--- a/ipeer-ubc-cwl-login/templates/nginx-configmap.yaml
+++ b/ipeer-ubc-cwl-login/templates/nginx-configmap.yaml
@@ -34,8 +34,8 @@ data:
         location ~ \.php$ {
           include fastcgi_params;
           fastcgi_index index.php;
-          fastcgi_read_timeout {{ .Values.web.timeout }}s;
-          fastcgi_send_timeout {{ .Values.web.timeout }}s;
+          fastcgi_read_timeout {{ .Values.web.timeout | default "60" }}s;
+          fastcgi_send_timeout {{ .Values.web.timeout | default "60" }}s;
           fastcgi_param REQUEST_METHOD $request_method;
           fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
           fastcgi_pass 127.0.0.1:9000;

--- a/ipeer-ubc-cwl-login/values.yaml
+++ b/ipeer-ubc-cwl-login/values.yaml
@@ -19,7 +19,7 @@ web:
     pullPolicy: IfNotPresent
     tag: "1.24-alpine"
   # set request timeout in seconds, some results need more time to calculate
-  timeout: "3000"
+  timeout: ""
 
 worker:
   enabled: false


### PR DESCRIPTION
While we could edit the values files to not define these ingresses, and let the chart template generate them as currently specified, I feel having the full list of all ingress prefixes in one place (the values file) is more readable and discoverable given that we only have 3.