### PR TITLE
iPeer: cleanup chart and copy over features from original chart

### DIFF
--- a/ipeer-ubc-cwl-login/.helmignore
+++ b/ipeer-ubc-cwl-login/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/ipeer-ubc-cwl-login/Chart.yaml
+++ b/ipeer-ubc-cwl-login/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.3.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/ipeer-ubc-cwl-login/templates/deployment.yaml
+++ b/ipeer-ubc-cwl-login/templates/deployment.yaml
@@ -75,7 +75,14 @@ replicas: {{ .Values.replicaCount }}
           - name: CALIPER_HOST
             value: {{ .Values.ipeer.caliper.host }}
           - name: CALIPER_API_KEY
-            value: {{ .Values.ipeer.caliper.apikey }}
+            {{- if .Values.ipeer.caliper.existingApiKeyRef }}
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.ipeer.caliper.existingApiKeyRef.name }}
+                key: {{ .Values.ipeer.caliper.existingApiKeyRef.key | default "apikey" }}
+            {{- else }}
+            value: {{ .Values.ipeer.caliper.apikey | quote }}
+            {{- end }}
           - name:  CALIPER_BASE_URL
             value: {{ .Values.ipeer.caliper.baseURL }}
           - name: CALIPER_ACTOR_BASE_URL
@@ -172,13 +179,13 @@ kind: Deployment
 metadata:
   name: {{ include "ipeer.fullname" . }}-worker
   labels:
-    compoment: worker
+    component: worker
     {{- include "ipeer.labels" . | nindent 4 }}
 spec:
   replicas: 1
   selector:
     matchLabels:
-      compoment: worker
+      component: worker
       {{- include "ipeer.selectorLabels" . | nindent 6 }}
   template:
     metadata:
@@ -187,7 +194,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
       labels:
-        compoment: worker
+        component: worker
         {{- include "ipeer.selectorLabels" . | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}

--- a/ipeer-ubc-cwl-login/templates/ingress.yaml
+++ b/ipeer-ubc-cwl-login/templates/ingress.yaml
@@ -21,9 +21,11 @@ metadata:
   name: {{ $fullName }}
   labels:
     {{- include "ipeer.labels" . | nindent 4 }}
-  {{- with .Values.ingress.annotations }}
   annotations:
     nginx.ingress.kubernetes.io/fastcgi-params-configmap: {{ $fullName }}
+    nginx.ingress.kubernetes.io/proxy-send-timeout: {{ .Values.web.timeout | quote }}
+    nginx.ingress.kubernetes.io/proxy-read-timeout: {{ .Values.web.timeout | quote }}
+  {{- with .Values.ingress.annotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:

--- a/ipeer-ubc-cwl-login/values.yaml
+++ b/ipeer-ubc-cwl-login/values.yaml
@@ -75,10 +75,6 @@ ingress:
     - host: ipeer-example.local
       paths: ['/']
   tls: []
-  #  - secretName: chart-example-tls
-  #    hosts:
-  #      - chart-example.local
-  samlServiceName: ""
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
@@ -106,7 +102,6 @@ tolerations: []
 affinity: {}
 
 ipeer:
-  secretKey: 'your_secret_key'
   jwtSecretKeyParm: 'id_parm_url'
   authShibbolethURL: 'https://shibboleth.url'
   session_save: database


### PR DESCRIPTION
Effective diff in staging:
```
metadata.labels  (apps/v1/Deployment/ipeer-stg-worker)
  - one map entry removed:     + one map entry added:
    compoment: worker            component: worker

spec.selector.matchLabels  (apps/v1/Deployment/ipeer-stg-worker)
  - one map entry removed:     + one map entry added:
    compoment: worker            component: worker

spec.template.metadata.labels  (apps/v1/Deployment/ipeer-stg-worker)
  - one map entry removed:     + one map entry added:
    compoment: worker            component: worker

metadata.annotations  (networking.k8s.io/v1/Ingress/ipeer-stg)
  + two map entries added:
    nginx.ingress.kubernetes.io/proxy-send-timeout: 300
    nginx.ingress.kubernetes.io/proxy-read-timeout: 300

```