### PR TITLE
Drop unsupported iPeer auth methods from chart

### DIFF
--- a/ipeer/Chart.yaml
+++ b/ipeer/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.0
+version: 0.6.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/ipeer/templates/NOTES.txt
+++ b/ipeer/templates/NOTES.txt
@@ -1,10 +1,6 @@
 1. Get the application URL by running these commands:
-{{- if .Values.ingress.enabled }}
-{{- range $host := .Values.ingress.hosts }}
-  {{- range .paths }}
-  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
-  {{- end }}
-{{- end }}
+{{- if .Values.ingress.host }}
+  http{{ if .Values.ingress.tls }}s{{ end }}://{{ .Values.ingress.host }}
 {{- else if contains "NodePort" .Values.service.type }}
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "ipeer.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")

--- a/ipeer/templates/deployment.yaml
+++ b/ipeer/templates/deployment.yaml
@@ -110,34 +110,6 @@ spec:
           {{- end }}
           - name: CUSTOM_AUTH_ERROR_MESSAGE
             value: {{ .Values.ipeer.auth.custom_error_message | quote }}
-          - name: IPEER_AUTH
-            value: {{ .Values.ipeer.auth.method }}
-          {{- if eq .Values.ipeer.auth.method "Ldap" }}
-          - name: IPEER_AUTH_LDAP_host
-            value: {{ .Values.ipeer.auth.ldap.host | quote }}
-          - name: IPEER_AUTH_LDAP_port
-            value: {{ .Values.ipeer.auth.ldap.port | quote }}
-          - name: IPEER_AUTH_LDAP_serviceUsername
-            value: {{ .Values.ipeer.auth.ldap.serviceUsername }}
-          - name: IPEER_AUTH_LDAP_servicePassword
-            value: {{ .Values.ipeer.auth.ldap.servicePassword }}
-          - name: IPEER_AUTH_LDAP_baseDn
-            value: {{ .Values.ipeer.auth.ldap.baseDn }}
-          - name: IPEER_AUTH_LDAP_usernameField
-            value: {{ .Values.ipeer.auth.ldap.usernameField }}
-          - name: IPEER_AUTH_LDAP_attributeSearchFilters
-            value: {{ .Values.ipeer.auth.ldap.attributeSearchFilters | quote }}
-          - name: IPEER_AUTH_LDAP_attributeMap
-            value: {{ .Values.ipeer.auth.ldap.attributeMap | quote }}
-          - name: IPEER_AUTH_LDAP_fallbackInternal
-            value: {{ .Values.ipeer.auth.ldap.fallbackInternal | quote }}
-          {{- end }}
-          {{- if eq .Values.ipeer.auth.method "Shibboleth" }}
-          - name: IPEER_AUTH_SHIBBOLETH_sessionInitiatorURL
-            value: {{ .Values.ipeer.auth.shibboleth.sessionInitiatorURL | quote }}
-          - name: IPEER_AUTH_SHIBBOLETH_logoutURL
-            value: {{ .Values.ipeer.auth.shibboleth.logoutURL | quote }}
-          {{- end }}
           {{- if .Values.ipeer.debug }}
           - name: IPEER_DEBUG
             value: "2"
@@ -234,15 +206,6 @@ spec:
           command: ["cake/console/cake"]
           args: ["worker", "run"]
           env:
-          - name: IPEER_SECRET_KEY
-            {{- if .Values.ipeer.auth.shibboleth.existingSecretKeyRef }}
-            valueFrom:
-              secretKeyRef:
-                name: {{ .Values.ipeer.auth.shibboleth.existingSecretKeyRef.name }}
-                key: {{ .Values.ipeer.auth.shibboleth.existingSecretKeyRef.key | default "secret-key" }}
-            {{- else }}
-            value: {{ .Values.ipeer.auth.shibboleth.secretKey | quote }}
-            {{- end }}
           - name: IPEER_DB_HOST
             value: {{ include "ipeer.databaseHost" .}}
           - name: IPEER_DB_PORT
@@ -270,7 +233,7 @@ spec:
             valueFrom:
               secretKeyRef:
                 name: {{ .Values.ipeer.caliper.existingApiKeyRef.name }}
-                key: {{ .Values.ipeer.caliper.existingApiKeyRef.key | default "apikey" }}
+                key: {{ .Values.ipeer.caliper.existingApiKeyRef.key | default "caliper-apikey" }}
             {{- else }}
             value: {{ .Values.ipeer.caliper.apikey | quote  }}
             {{- end }}
@@ -280,36 +243,6 @@ spec:
             value: {{ .Values.ipeer.caliper.actorBaseURL }}
           - name: CALIPER_ACTOR_UNIQUE_IDENTIFIER_PARAM
             value: {{ .Values.ipeer.caliper.actorUniqueIdParam }}
-          {{- end }}
-          - name: CUSTOM_AUTH_ERROR_MESSAGE
-            value: {{ .Values.ipeer.auth.custom_error_message | quote }}
-          - name: IPEER_AUTH
-            value: {{ .Values.ipeer.auth.method }}
-          {{- if eq .Values.ipeer.auth.method "Ldap" }}
-          - name: IPEER_AUTH_LDAP_host
-            value: {{ .Values.ipeer.auth.ldap.host | quote }}
-          - name: IPEER_AUTH_LDAP_port
-            value: {{ .Values.ipeer.auth.ldap.port | quote }}
-          - name: IPEER_AUTH_LDAP_serviceUsername
-            value: {{ .Values.ipeer.auth.ldap.serviceUsername }}
-          - name: IPEER_AUTH_LDAP_servicePassword
-            value: {{ .Values.ipeer.auth.ldap.servicePassword }}
-          - name: IPEER_AUTH_LDAP_baseDn
-            value: {{ .Values.ipeer.auth.ldap.baseDn }}
-          - name: IPEER_AUTH_LDAP_usernameField
-            value: {{ .Values.ipeer.auth.ldap.usernameField }}
-          - name: IPEER_AUTH_LDAP_attributeSearchFilters
-            value: {{ .Values.ipeer.auth.ldap.attributeSearchFilters | quote }}
-          - name: IPEER_AUTH_LDAP_attributeMap
-            value: {{ .Values.ipeer.auth.ldap.attributeMap | quote }}
-          - name: IPEER_AUTH_LDAP_fallbackInternal
-            value: {{ .Values.ipeer.auth.ldap.fallbackInternal | quote }}
-          {{- end }}
-          {{- if eq .Values.ipeer.auth.method "Shibboleth" }}
-          - name: IPEER_AUTH_SHIBBOLETH_sessionInitiatorURL
-            value: {{ .Values.ipeer.auth.shibboleth.sessionInitiatorURL | quote }}
-          - name: IPEER_AUTH_SHIBBOLETH_logoutURL
-            value: {{ .Values.ipeer.auth.shibboleth.logoutURL | quote }}
           {{- end }}
           {{- if .Values.ipeer.debug }}
           - name: IPEER_DEBUG

--- a/ipeer/templates/ingress.yaml
+++ b/ipeer/templates/ingress.yaml
@@ -19,8 +19,10 @@ metadata:
     {{- include "ipeer.labels" . | nindent 4 }}
   annotations:
     nginx.ingress.kubernetes.io/fastcgi-params-configmap: {{ $fullName }}
+    {{- if .Values.web_proxy.request_timeout }}
     nginx.ingress.kubernetes.io/proxy-send-timeout: {{ .Values.web_proxy.request_timeout | quote }}
     nginx.ingress.kubernetes.io/proxy-read-timeout: {{ .Values.web_proxy.request_timeout | quote }}
+    {{- end }}
   {{- with .Values.ingress.annotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/ipeer/values.yaml
+++ b/ipeer/values.yaml
@@ -1,7 +1,3 @@
-# Default values for ipeer.
-# This is a YAML-formatted file...
-# Declare variables to be passed into your templates.
-
 stage: dev
 
 app:
@@ -14,8 +10,7 @@ app:
     targetMemoryUtilizationPercentage: 70
   image:
     repository: ubcctlt/ipeer
-    pullPolicy: IfNotPresent
-    # Overrides the image tag whose default is the chart appVersion.
+    pullPolicy: Always
     tag: ""
 
 web_proxy:
@@ -82,9 +77,7 @@ ipeer:
   # Default contact email address exposed to the application; override per environment.
   supportEmail: ''
   auth:
-    method: default
     custom_error_message: ''
-    ldap: {}
     shibboleth: {}
   caliper:
     enabled: false


### PR DESCRIPTION
These auth methods are technically supported by the Guard plugin, but attempting to activate them now would result in errors, as the corresponding php extensions and other dependencies are unavailable in the currently built iPeer images.