### PR TITLE
mariadb: only enable replica bootstrapFrom if physical backups enabled

### DIFF
--- a/mariadb/Chart.yaml
+++ b/mariadb/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: mariadb
 description: A Helm chart for MariaDB
 type: application
-version: 0.1.17
+version: 0.1.18
 appVersion: "10.6"

--- a/mariadb/templates/mariadb.yaml
+++ b/mariadb/templates/mariadb.yaml
@@ -48,9 +48,11 @@ spec:
         errorDurationThreshold: {{ .Values.secondary.replica.recovery.errorDurationThreshold }}
         {{- end }}
       {{- end }}
+      {{- if and .Values.backup.enabled (eq .Values.backup.type "physical") }}
       bootstrapFrom:
         physicalBackupTemplateRef:
           name: {{ include "mariadb.fullname" . }}-physicalbackup
+      {{- end }}
     {{- if .Values.secondary.semiSync.enabled }}
     semiSyncEnabled: true
     semiSyncAckTimeout: 10s


### PR DESCRIPTION
Currently a DB which has not yet switched to physical backups will still refer to a yet-to-be-created physical backup in the replica bootstrapFrom settings.

Example:
<img width="1122" height="253" alt="image" src="https://github.com/user-attachments/assets/e8f762cd-5241-4616-b536-ea5ebd582dc9" />

(ipeer-prod-db-physicalbackup does not exist)