### PR TITLE
Update init-db command to use new Flask CLI custom command

### DIFF
--- a/compair/Chart.yaml
+++ b/compair/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - peer learning
   - education
 name: compair
-version: 0.10.8
+version: 0.10.9
 appVersion: 1.3.3
 home: http://ubc.github.io/compair/
 sources:

--- a/compair/Chart.yaml
+++ b/compair/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
   - education
 name: compair
 version: 0.10.9
-appVersion: 1.3.3
+appVersion: 1.3.5
 home: http://ubc.github.io/compair/
 sources:
   - http://github.com/ubc/compair

--- a/compair/templates/compair-deployment.yaml
+++ b/compair/templates/compair-deployment.yaml
@@ -325,7 +325,7 @@ spec:
       {{- if not .Values.db.bootstrapFrom }}
       - name: init-db
         image: "{{ .Values.app.image.repository }}:{{ .Values.app.image.tag | default .Chart.AppVersion }}"
-        command: ["sh", "-c", "python manage.py database create {{ if .Values.demoInstance }}--sample_data{{ end }}"]
+        command: ["sh", "-c", "FLASK_APP=manage flask database create{{ if .Values.demoInstance }} --sample-data{{ end }}"]
         imagePullPolicy: {{ .Values.app.image.pullPolicy }}
         env:
         - name: DB_HOST


### PR DESCRIPTION
ComPAIR is currently using flask-script custom commands, but since that project is deprecated and Flask has a built-in CLI that allows for custom commands, we have updated it to use the Flask CLI commands instead.

`--sample_data` flag changed to `--sample-data` to follow Flask CLI conventions (camel case instead of snake case).

PR in ComPAIR: https://github.com/ubc/compair/pull/1075

I won't be merging to master until exam period is over just to avoid different image and chart versions across environments. Will merge after exam period when we update the prod config with new image.