### PR TITLE
Increase memory limit to 128Mi from 100Mi for ComPAIR worker scheduler

### DIFF
--- a/compair/Chart.yaml
+++ b/compair/Chart.yaml
@@ -6,8 +6,8 @@ keywords:
   - peer learning
   - education
 name: compair
-version: 0.10.9
-appVersion: 1.3.5
+version: 0.10.10
+appVersion: 1.3.6
 home: http://ubc.github.io/compair/
 sources:
   - http://github.com/ubc/compair

--- a/compair/values.yaml
+++ b/compair/values.yaml
@@ -184,7 +184,7 @@ worker:
   resources:
     limits:
     #  cpu: 100m
-      memory: 800Mi
+      memory: 1024Mi
     requests:
     #  cpu: 100m
       memory: 512Mi

--- a/compair/values.yaml
+++ b/compair/values.yaml
@@ -193,7 +193,7 @@ scheduler:
   resources:
     limits:
     #  cpu: 100m
-      memory: 100Mi
+      memory: 128Mi
     requests:
     #  cpu: 100m
       memory: 64Mi


### PR DESCRIPTION
Noticed `%mem/L` is `~91` for worker scheduler pod after the ComPAIR `v1.3.4` release. It included the `python 3.8 -> python 3.10`, `celery 5.2.6 -> 5.6.2`, and `kombu 5.2.4 -> 5.6.2` upgrades, which could possibly be a reason for the increase. It increased `~10MiB` from `v1.3.3`. Also, staging's worker scheduler pod restarted twice due to `OOMKilled` (probably hit 100+ MiB very briefly). Looks stable now but it's too close to our current limit.

So this PR is for increasing limit from `100Mi` to `128Mi` to leave some headroom.

Currently looking into memory increase for demo worker pod after flask 2 upgrade deployment (went from ~470MiB to ~765MiB)