### PR TITLE
feat(course-directory): pre-upgrade migration Job; bump to 0.2.0

### DIFF
--- a/course-directory/Chart.yaml
+++ b/course-directory/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/course-directory/templates/_helpers.tpl
+++ b/course-directory/templates/_helpers.tpl
@@ -62,3 +62,63 @@ Return the MariaDB Hostname
     {{- end -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Common pod env block — used by both the Deployment and the migration Job
+so they stay in sync. Keep this in one place; do not duplicate the env list
+into individual templates.
+*/}}
+{{- define "ltic-access-request.podEnv" -}}
+- name: POSTGRES_USER
+  value: {{ .Values.db.username }}
+- name: POSTGRES_PASSWORD
+  value: {{ .Values.db.password }}
+- name: POSTGRES_DB
+  value: {{ .Values.db.name }}
+- name: POSTGRES_HOST
+  value: {{ .Values.db.host }}
+- name: DATABASE_URL
+  value: {{ printf "postgresql+psycopg://%s:%s@%s:5432/%s" .Values.db.username .Values.db.password .Values.db.host .Values.db.name | quote }}
+- name: DB_PASSWORD
+  value: {{ .Values.db.password }}
+- name: FLASK_ENV
+  value: {{ .Values.app.flask.env }}
+- name: SECRET_KEY
+  value: {{ .Values.app.flask.secretKey }}
+- name: SMTP_HOST
+  value: {{ .Values.app.smtp.host }}
+- name: SMTP_PORT
+  value: {{ .Values.app.smtp.port | quote}}
+- name: SMTP_USE_TLS
+  value: {{ .Values.app.smtp.useTls | quote }}
+- name: SMTP_USER
+  value: {{ .Values.app.smtp.user }}
+- name: SMTP_PASSWORD
+  value: {{ .Values.app.smtp.password }}
+- name: SMTP_FROM
+  value: {{ .Values.app.smtp.from }}
+- name: ALLOWED_EMAIL_DOMAINS
+  value: {{ .Values.app.smtp.allowedEmailDomains }}
+- name: BASE_URL
+  value: https://{{ .Values.ingress.host }}
+{{- if .Values.saml.enabled }}
+{{- $samlBaseUrl := .Values.saml.serviceProvider.baseUrl | default (printf "https://%s" .Values.ingress.host) }}
+{{- $samlEntityId := .Values.saml.serviceProvider.entityId | default (printf "%s/auth/saml/metadata" $samlBaseUrl) }}
+- name: SAML_ENABLED
+  value: "true"
+- name: SAML_SP_BASE_URL
+  value: {{ $samlBaseUrl | quote }}
+- name: SAML_SP_ENTITY_ID
+  value: {{ $samlEntityId | quote }}
+- name: SAML_SP_CERT_PATH
+  value: {{ printf "%s/%s" .Values.saml.serviceProvider.certMountPath .Values.saml.serviceProvider.certFilename | quote }}
+- name: SAML_SP_KEY_PATH
+  value: {{ printf "%s/%s" .Values.saml.serviceProvider.certMountPath .Values.saml.serviceProvider.keyFilename | quote }}
+- name: SAML_IDP_METADATA_PATH
+  value: {{ printf "%s/%s" .Values.saml.serviceProvider.certMountPath .Values.saml.serviceProvider.metadataFilename | quote }}
+- name: SAML_CONTACT_NAME
+  value: {{ .Values.saml.contact.name | quote }}
+- name: SAML_CONTACT_EMAIL
+  value: {{ .Values.saml.contact.email | quote }}
+{{- end }}
+{{- end -}}

--- a/course-directory/templates/deployment.yaml
+++ b/course-directory/templates/deployment.yaml
@@ -59,58 +59,7 @@ spec:
             {{- end }}
           {{- end }}
           env:
-            - name: POSTGRES_USER
-              value: {{ .Values.db.username }}
-            - name: POSTGRES_PASSWORD
-              value: {{ .Values.db.password }}
-            - name: POSTGRES_DB
-              value: {{ .Values.db.name }}
-            - name: POSTGRES_HOST
-              value: {{ .Values.db.host }}
-            - name: DATABASE_URL
-              value: {{ printf "postgresql+psycopg://%s:%s@%s:5432/%s" .Values.db.username .Values.db.password .Values.db.host .Values.db.name | quote }}
-            - name: DB_PASSWORD
-              value: {{ .Values.db.password }}
-            - name: FLASK_ENV
-              value: {{ .Values.app.flask.env }}
-            - name: SECRET_KEY
-              value: {{ .Values.app.flask.secretKey }}
-            - name: SMTP_HOST
-              value: {{ .Values.app.smtp.host }}
-            - name: SMTP_PORT
-              value: {{ .Values.app.smtp.port | quote}}
-            - name: SMTP_USE_TLS
-              value: {{ .Values.app.smtp.useTls | quote }}
-            - name: SMTP_USER
-              value: {{ .Values.app.smtp.user }}
-            - name: SMTP_PASSWORD
-              value: {{ .Values.app.smtp.password }}
-            - name: SMTP_FROM
-              value: {{ .Values.app.smtp.from }}
-            - name: ALLOWED_EMAIL_DOMAINS
-              value: {{ .Values.app.smtp.allowedEmailDomains }}
-            - name: BASE_URL
-              value: https://{{ .Values.ingress.host }}
-            {{- if .Values.saml.enabled }}
-            {{- $samlBaseUrl := .Values.saml.serviceProvider.baseUrl | default (printf "https://%s" .Values.ingress.host) }}
-            {{- $samlEntityId := .Values.saml.serviceProvider.entityId | default (printf "%s/auth/saml/metadata" $samlBaseUrl) }}
-            - name: SAML_ENABLED
-              value: "true"
-            - name: SAML_SP_BASE_URL
-              value: {{ $samlBaseUrl | quote }}
-            - name: SAML_SP_ENTITY_ID
-              value: {{ $samlEntityId | quote }}
-            - name: SAML_SP_CERT_PATH
-              value: {{ printf "%s/%s" .Values.saml.serviceProvider.certMountPath .Values.saml.serviceProvider.certFilename | quote }}
-            - name: SAML_SP_KEY_PATH
-              value: {{ printf "%s/%s" .Values.saml.serviceProvider.certMountPath .Values.saml.serviceProvider.keyFilename | quote }}
-            - name: SAML_IDP_METADATA_PATH
-              value: {{ printf "%s/%s" .Values.saml.serviceProvider.certMountPath .Values.saml.serviceProvider.metadataFilename | quote }}
-            - name: SAML_CONTACT_NAME
-              value: {{ .Values.saml.contact.name | quote }}
-            - name: SAML_CONTACT_EMAIL
-              value: {{ .Values.saml.contact.email | quote }}
-            {{- end }}
+            {{- include "ltic-access-request.podEnv" . | nindent 12 }}
       {{- if or .Values.volumes .Values.saml.enabled }}
       volumes:
         {{- with .Values.volumes }}

--- a/course-directory/templates/migration-job.yaml
+++ b/course-directory/templates/migration-job.yaml
@@ -1,0 +1,70 @@
+{{- if .Values.migrations.enabled }}
+{{/*
+Database migration Job — runs `flask db upgrade` once per Helm release
+revision before any pod is created or restarted.
+
+This is a Helm pre-install / pre-upgrade hook. With this in place,
+multiple replicas can be scaled safely: the schema is already at head
+by the time pods start, so each pod's defensive `flask db upgrade` in
+entrypoint.sh becomes a fast no-op.
+
+The Job name is suffixed with .Release.Revision so each upgrade
+creates a distinct Job (Helm refuses to recreate an existing hook
+resource by default). hook-delete-policy reaps prior succeeded
+revisions on the next install/upgrade.
+*/}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "ltic-access-request.fullname" . }}-migrate-r{{ .Release.Revision }}
+  labels:
+    {{- include "ltic-access-request.labels" . | nindent 4 }}
+    app.kubernetes.io/component: migrate
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: {{ .Values.migrations.backoffLimit | default 1 }}
+  ttlSecondsAfterFinished: {{ .Values.migrations.ttlSecondsAfterFinished | default 300 }}
+  template:
+    metadata:
+      labels:
+        {{- include "ltic-access-request.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: migrate
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      restartPolicy: OnFailure
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: migrate
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -e
+              echo "Waiting for postgres at ${POSTGRES_HOST}..."
+              until pg_isready -h "${POSTGRES_HOST}" -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" >/dev/null 2>&1; do
+                sleep 1
+              done
+              echo "Postgres reachable. Running flask db upgrade..."
+              flask db upgrade
+              echo "Migrations complete."
+          env:
+            {{- include "ltic-access-request.podEnv" . | nindent 12 }}
+          {{- with .Values.migrations.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+{{- end }}

--- a/course-directory/values.yaml
+++ b/course-directory/values.yaml
@@ -149,3 +149,17 @@ externalSecret:
   secretStoreRefName: ""
   secretStoreRefKind: ClusterSecretStore  # or SecretStore
   refreshInterval: 1h
+
+# Database migration Job — Helm pre-install/pre-upgrade hook that runs
+# `flask db upgrade` once per release revision before any pod is created.
+# Required for safe multi-replica deployments (otherwise N pods race the
+# upgrade on simultaneous start). Disable only for emergency manual
+# rollback scenarios.
+migrations:
+  enabled: true
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 300
+  resources: {}
+    # requests:
+    #   cpu: 50m
+    #   memory: 128Mi


### PR DESCRIPTION
## Summary

- Add a Helm pre-install/pre-upgrade hook Job that runs \`flask db upgrade\` once per release revision before any pod is created or restarted.
- Refactor the deployment env block into a \`course-directory.podEnv\` partial in \`_helpers.tpl\` so the Deployment and the migration Job share one source of truth.
- Bump chart \`version\` from \`0.1.0\` → \`0.2.0\`.

## Why

\`course-directory\` runs \`flask db upgrade\` in its pod entrypoint. With one replica that's fine. With multiple replicas coming up simultaneously (rolling deploy, scale-up), N pods race the same alembic upgrade. Alembic usually serializes via the \`alembic_version\` row, but this is fragile: lock contention can extend pod startup, trip readiness probes, and produce confusing logs.

Moving the migration into a Helm pre-upgrade hook means the schema is at head **before** any pod starts. Each pod's defensive \`flask db upgrade\` becomes a fast no-op.

## What's not covered

This PR handles forward migrations only.

**Helm rollback does NOT trigger a DB downgrade** — the hook list is \`pre-install,pre-upgrade\`, not \`pre-rollback\`. A Helm rollback re-applies the prior Deployment manifest but leaves the schema at the newer revision; the old image then runs against new schema. For breaking migrations (e.g. \`feat/course-materials-list\` which dropped \`Course.materials\`), this would crash the old code.

The intended pattern is **roll forward** (deploy a fix-forward migration). For the rare emergency where schema rollback really is needed, the recipe is:

\`\`\`bash
POD=\$(kubectl -n course-directory get pods -l app.kubernetes.io/name=course-directory -o name | head -1)
kubectl -n course-directory exec "\$POD" -- flask db downgrade <target-rev>
helm -n course-directory rollback <release> <revision>
\`\`\`

A \`pre-rollback\` automated Job is possible but the target revision has to come from somewhere (chart values? the prior chart's appVersion?), and our existing migrations are documented as lossy on downgrade — so it's a sharper tool. Punted out of scope.

## Testing

- \`helm lint .\` clean
- \`helm template test .\` renders the Deployment (env block via partial) and the Job (with hook annotations) byte-for-byte equivalent env blocks
- Job name templated with \`.Release.Revision\` so each upgrade creates a distinct hook resource (avoids \`helm.sh/hook-delete-policy: before-hook-creation\` race surprises)
- Validated with \`saml.enabled=true\` and \`saml.enabled=false\`

## Test plan

- [ ] Run \`helm upgrade\` against staging — confirm a Job appears, runs to completion, and the Deployment rollout proceeds.
- [ ] Run \`helm upgrade\` again with no schema changes — confirm the Job runs, hits 'already at head', exits 0.
- [ ] Confirm \`migrations.enabled: false\` in values disables the Job.