### PR TITLE
fix(course-directory): mount SAML certs in migration Job; bump 0.2.1

### DIFF
--- a/course-directory/Chart.yaml
+++ b/course-directory/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/course-directory/templates/migration-job.yaml
+++ b/course-directory/templates/migration-job.yaml
@@ -63,8 +63,27 @@ spec:
               echo "Migrations complete."
           env:
             {{- include "ltic-access-request.podEnv" . | nindent 12 }}
+          {{- if .Values.saml.enabled }}
+          volumeMounts:
+            - name: saml-certs
+              mountPath: {{ .Values.saml.serviceProvider.certMountPath }}
+              readOnly: true
+          {{- end }}
           {{- with .Values.migrations.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+      {{- if .Values.saml.enabled }}
+      volumes:
+        - name: saml-certs
+          secret:
+            secretName: {{ include "ltic-access-request.fullname" . }}-saml
+            items:
+              - key: {{ .Values.saml.serviceProvider.keySecretKey }}
+                path: {{ .Values.saml.serviceProvider.keyFilename }}
+              - key: {{ .Values.saml.serviceProvider.certSecretKey }}
+                path: {{ .Values.saml.serviceProvider.certFilename }}
+              - key: {{ .Values.saml.serviceProvider.metadataSecretKey }}
+                path: {{ .Values.saml.serviceProvider.metadataFilename }}
+      {{- end }}
 {{- end }}


### PR DESCRIPTION
## Summary

Bug in 0.2.0: the pre-upgrade migration Job inherits the Deployment's env (including `SAML_ENABLED=true` when SAML is configured) but doesn't mount the SAML cert volume. Flask's `create_app()` reads `/etc/saml/sp.crt` eagerly during `flask db upgrade` boot, so the Job crashes before running any alembic command.

This fix mounts the same secret-backed `saml-certs` volume the Deployment uses, gated on `saml.enabled`.

## Repro / detection

Staging deploy of `course-directory` chart 0.2.0 with `saml.enabled=true` failed at the pre-upgrade hook:

```
Error: UPGRADE FAILED: ... pre-upgrade hooks failed:
* job staging-migrate-r27 failed: BackoffLimitExceeded
```

Manually replaying the Job's command in a debug pod surfaced the actual cause:

```
SAMLSettingsError: SP cert not found at /etc/saml/sp.crt
```

## Test plan

- [x] `helm lint`
- [x] `helm template` confirms `volumeMounts` and `volumes` are rendered when `saml.enabled=true`, omitted when `saml.enabled=false`
- [ ] Apply 0.2.1 against staging, confirm migration Job pod boots and `flask db upgrade` runs cleanly