### PR TITLE
Add Helm chart for canvas-bridge

### DIFF
--- a/canvas-bridge/.helmignore
+++ b/canvas-bridge/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/canvas-bridge/Chart.yaml
+++ b/canvas-bridge/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: canvas-bridge
+description: FastAPI service bridging Canvas LMS course exports into WordPress (UBC Blogs)
+type: application
+version: 0.1.0
+appVersion: "latest"

--- a/canvas-bridge/templates/_helpers.tpl
+++ b/canvas-bridge/templates/_helpers.tpl
@@ -1,0 +1,51 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "canvas-bridge.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "canvas-bridge.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "canvas-bridge.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "canvas-bridge.labels" -}}
+helm.sh/chart: {{ include "canvas-bridge.chart" . }}
+{{ include "canvas-bridge.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "canvas-bridge.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "canvas-bridge.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/canvas-bridge/templates/_validate.tpl
+++ b/canvas-bridge/templates/_validate.tpl
@@ -1,0 +1,20 @@
+{{/*
+Validation guards. Renders nothing; called via:
+  {{- include "canvas-bridge.validate" . -}}
+from any always-rendered file. Fails `helm template` early with an
+actionable message instead of letting a misconfig boot a broken pod.
+*/}}
+{{- define "canvas-bridge.validate" -}}
+{{- if not .Values.app.baseUrl -}}
+{{- fail "app.baseUrl is required (e.g. https://canvas-bridge-stg.ltic.ubc.ca)" -}}
+{{- end -}}
+{{- if and .Values.ingress.enabled (not .Values.ingress.host) -}}
+{{- fail "ingress.host is required when ingress.enabled=true" -}}
+{{- end -}}
+{{- if not .Values.externalSecret.secretStoreRefName -}}
+{{- fail "externalSecret.secretStoreRefName is required" -}}
+{{- end -}}
+{{- if not .Values.externalSecret.path -}}
+{{- fail "externalSecret.path is required (e.g. canvas-bridge/staging)" -}}
+{{- end -}}
+{{- end -}}

--- a/canvas-bridge/templates/cronjob.yaml
+++ b/canvas-bridge/templates/cronjob.yaml
@@ -1,0 +1,59 @@
+{{- if .Values.cleanup.enabled }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "canvas-bridge.fullname" . }}-cleanup
+  labels:
+    {{- include "canvas-bridge.labels" . | nindent 4 }}
+spec:
+  schedule: {{ .Values.cleanup.schedule | quote }}
+  concurrencyPolicy: {{ .Values.cleanup.concurrencyPolicy }}
+  successfulJobsHistoryLimit: {{ .Values.cleanup.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.cleanup.failedJobsHistoryLimit }}
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            {{- include "canvas-bridge.selectorLabels" . | nindent 12 }}
+            app.kubernetes.io/component: cleanup
+        spec:
+          restartPolicy: OnFailure
+          {{- with .Values.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          containers:
+            - name: cleanup
+              image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+              imagePullPolicy: {{ .Values.image.pullPolicy }}
+              command: ["python", "-m", "app.cleanup"]
+              env:
+                - name: DATA_DIR
+                  value: /data/uploads
+                - name: RETENTION_HOURS
+                  value: {{ .Values.app.retentionHours | quote }}
+              volumeMounts:
+                - name: uploads
+                  mountPath: /data/uploads
+              {{- with .Values.cleanup.resources }}
+              resources:
+                {{- toYaml . | nindent 16 }}
+              {{- end }}
+          volumes:
+            - name: uploads
+              persistentVolumeClaim:
+                claimName: {{ include "canvas-bridge.fullname" . }}-uploads
+          {{- with .Values.nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.tolerations }}
+          tolerations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.affinity }}
+          affinity:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+{{- end }}

--- a/canvas-bridge/templates/deployment.yaml
+++ b/canvas-bridge/templates/deployment.yaml
@@ -1,0 +1,134 @@
+{{- include "canvas-bridge.validate" . -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "canvas-bridge.fullname" . }}
+  labels:
+    {{- include "canvas-bridge.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "canvas-bridge.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "canvas-bridge.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        - name: uploads
+          persistentVolumeClaim:
+            claimName: {{ include "canvas-bridge.fullname" . }}-uploads
+        - name: tus-staging
+          persistentVolumeClaim:
+            claimName: {{ include "canvas-bridge.fullname" . }}-tus-staging
+      containers:
+        - name: app
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: fastapi
+              containerPort: 8000
+              protocol: TCP
+          env:
+            - name: BASE_URL
+              value: {{ .Values.app.baseUrl | quote }}
+            - name: ENVIRONMENT
+              value: {{ .Values.app.environment | quote }}
+            - name: DATA_DIR
+              value: /data/uploads
+            - name: RETENTION_HOURS
+              value: {{ .Values.app.retentionHours | quote }}
+            - name: SAML_ENTITY_ID
+              value: {{ .Values.app.samlEntityId | default .Values.app.baseUrl | quote }}
+            - name: SESSION_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "canvas-bridge.fullname" . }}
+                  key: session-secret
+            - name: SAML_SP_CERT
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "canvas-bridge.fullname" . }}
+                  key: saml-sp-cert
+            - name: SAML_SP_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "canvas-bridge.fullname" . }}
+                  key: saml-sp-key
+            - name: SAML_IDP_CERT
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "canvas-bridge.fullname" . }}
+                  key: saml-idp-cert
+          volumeMounts:
+            - name: uploads
+              mountPath: /data/uploads
+            - name: tus-staging
+              mountPath: /data/tus-staging
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: fastapi
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: fastapi
+          {{- with .Values.app.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+
+        - name: tusd
+          image: "{{ .Values.tusd.image.repository }}:{{ .Values.tusd.image.tag }}"
+          imagePullPolicy: {{ .Values.tusd.image.pullPolicy }}
+          args:
+            - --upload-dir=/data/tus-staging
+            - --host=0.0.0.0
+            - --port=8080
+            - --hooks-http=http://localhost:8000/api/tus-hook
+            - --hooks-enabled-events=post-finish
+            - --max-size=10737418240
+          ports:
+            - name: tusd
+              containerPort: 8080
+              protocol: TCP
+          volumeMounts:
+            - name: tus-staging
+              mountPath: /data/tus-staging
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: tusd
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: tusd
+          {{- with .Values.tusd.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/canvas-bridge/templates/deployment.yaml
+++ b/canvas-bridge/templates/deployment.yaml
@@ -49,10 +49,16 @@ spec:
               value: {{ .Values.app.environment | quote }}
             - name: DATA_DIR
               value: /data/uploads
+            - name: AUDIT_LOG_PATH
+              value: /data/uploads/audit/audit.log
             - name: RETENTION_HOURS
               value: {{ .Values.app.retentionHours | quote }}
             - name: SAML_ENTITY_ID
               value: {{ .Values.app.samlEntityId | default .Values.app.baseUrl | quote }}
+            - name: SAML_ACS_PATH
+              value: {{ .Values.app.samlAcsPath | quote }}
+            - name: SAML_SLO_PATH
+              value: {{ .Values.app.samlSloPath | quote }}
             - name: SESSION_SECRET
               valueFrom:
                 secretKeyRef:

--- a/canvas-bridge/templates/deployment.yaml
+++ b/canvas-bridge/templates/deployment.yaml
@@ -18,6 +18,7 @@ spec:
       {{- end }}
       labels:
         {{- include "canvas-bridge.labels" . | nindent 8 }}
+        app.kubernetes.io/component: web
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/canvas-bridge/templates/externalsecret.yaml
+++ b/canvas-bridge/templates/externalsecret.yaml
@@ -1,0 +1,31 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ include "canvas-bridge.fullname" . }}
+  labels:
+    {{- include "canvas-bridge.labels" . | nindent 4 }}
+spec:
+  refreshInterval: {{ .Values.externalSecret.refreshInterval }}
+  secretStoreRef:
+    name: {{ .Values.externalSecret.secretStoreRefName }}
+    kind: {{ .Values.externalSecret.secretStoreRefKind }}
+  target:
+    name: {{ include "canvas-bridge.fullname" . }}
+    creationPolicy: Owner
+  data:
+    - secretKey: session-secret
+      remoteRef:
+        key: {{ .Values.externalSecret.path }}
+        property: {{ .Values.externalSecret.properties.sessionSecret }}
+    - secretKey: saml-sp-cert
+      remoteRef:
+        key: {{ .Values.externalSecret.path }}
+        property: {{ .Values.externalSecret.properties.samlSpCert }}
+    - secretKey: saml-sp-key
+      remoteRef:
+        key: {{ .Values.externalSecret.path }}
+        property: {{ .Values.externalSecret.properties.samlSpKey }}
+    - secretKey: saml-idp-cert
+      remoteRef:
+        key: {{ .Values.externalSecret.path }}
+        property: {{ .Values.externalSecret.properties.samlIdpCert }}

--- a/canvas-bridge/templates/ingress.yaml
+++ b/canvas-bridge/templates/ingress.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "canvas-bridge.fullname" . }}
+  labels:
+    {{- include "canvas-bridge.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.class }}
+  ingressClassName: {{ .Values.ingress.class }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.ingress.host }}
+      http:
+        paths:
+          - path: /files/
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "canvas-bridge.fullname" . }}-tusd
+                port:
+                  number: 8080
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "canvas-bridge.fullname" . }}-app
+                port:
+                  number: 8000
+  {{- if and (hasKey .Values.ingress.annotations "kubernetes.io/tls-acme") (index .Values.ingress.annotations "kubernetes.io/tls-acme" | eq "true") }}
+  tls:
+    - hosts:
+        - {{ .Values.ingress.host }}
+      secretName: {{ .Values.ingress.tlsSecretName | default (printf "%s-tls" (include "canvas-bridge.fullname" .)) }}
+  {{- end }}
+{{- end }}

--- a/canvas-bridge/templates/ingress.yaml
+++ b/canvas-bridge/templates/ingress.yaml
@@ -31,7 +31,7 @@ spec:
                 name: {{ include "canvas-bridge.fullname" . }}-app
                 port:
                   number: 8000
-  {{- if and (hasKey .Values.ingress.annotations "kubernetes.io/tls-acme") (index .Values.ingress.annotations "kubernetes.io/tls-acme" | eq "true") }}
+  {{- if .Values.ingress.tls }}
   tls:
     - hosts:
         - {{ .Values.ingress.host }}

--- a/canvas-bridge/templates/pvc.yaml
+++ b/canvas-bridge/templates/pvc.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "canvas-bridge.fullname" . }}-uploads
+  labels:
+    {{- include "canvas-bridge.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.uploads.accessMode }}
+  storageClassName: {{ .Values.persistence.uploads.storageClass }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.uploads.size }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "canvas-bridge.fullname" . }}-tus-staging
+  labels:
+    {{- include "canvas-bridge.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.tusStaging.accessMode }}
+  storageClassName: {{ .Values.persistence.tusStaging.storageClass }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.tusStaging.size }}

--- a/canvas-bridge/templates/service.yaml
+++ b/canvas-bridge/templates/service.yaml
@@ -13,6 +13,7 @@ spec:
       name: http
   selector:
     {{- include "canvas-bridge.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: web
 ---
 apiVersion: v1
 kind: Service
@@ -29,3 +30,4 @@ spec:
       name: http
   selector:
     {{- include "canvas-bridge.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: web

--- a/canvas-bridge/templates/service.yaml
+++ b/canvas-bridge/templates/service.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "canvas-bridge.fullname" . }}-app
+  labels:
+    {{- include "canvas-bridge.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: 8000
+      targetPort: fastapi
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "canvas-bridge.selectorLabels" . | nindent 4 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "canvas-bridge.fullname" . }}-tusd
+  labels:
+    {{- include "canvas-bridge.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: 8080
+      targetPort: tusd
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "canvas-bridge.selectorLabels" . | nindent 4 }}

--- a/canvas-bridge/values.yaml
+++ b/canvas-bridge/values.yaml
@@ -1,0 +1,88 @@
+# Default values for canvas-bridge.
+
+image:
+  repository: gcr.io/ctlt-apps/canvas-bridge
+  tag: ""
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+
+nameOverride: ""
+fullnameOverride: ""
+
+podAnnotations: {}
+podLabels: {}
+
+service:
+  type: ClusterIP
+
+ingress:
+  enabled: true
+  class: nginx
+  annotations:
+    kubernetes.io/tls-acme: "true"
+    # Allow large zip uploads through to tusd (up to its --max-size limit).
+    nginx.ingress.kubernetes.io/proxy-body-size: "0"
+    nginx.ingress.kubernetes.io/proxy-request-buffering: "off"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+  host: ""
+  # Auto-generated from fullname if empty.
+  tlsSecretName: ""
+
+# App container (FastAPI/uvicorn on port 8000)
+app:
+  baseUrl: ""           # e.g. https://canvas-bridge-stg.ltic.ubc.ca
+  environment: staging  # staging or production — selects CWL IdP endpoints
+  retentionHours: 24
+  # Defaults to baseUrl when empty.
+  samlEntityId: ""
+  resources: {}
+
+# tusd sidecar (resumable uploads on port 8080)
+tusd:
+  image:
+    repository: tusproject/tusd
+    tag: v2.6.0
+    pullPolicy: IfNotPresent
+  resources: {}
+
+# Persistent storage — use csi-rbd (Ceph RBD). Do NOT use NFS storage classes
+# (nfs-storage, nfs-moodle-prod, etc.); zip extraction is I/O intensive and
+# NFS causes failures under load.
+persistence:
+  uploads:
+    storageClass: csi-rbd
+    size: 1Ti
+    accessMode: ReadWriteOnce
+  tusStaging:
+    storageClass: csi-rbd
+    size: 100Gi
+    accessMode: ReadWriteOnce
+
+# ExternalSecret (external-secrets.io/v1) — pulls all sensitive values from a
+# single Vault path. Set `properties.*` to match Vault property names if they
+# differ from the defaults.
+externalSecret:
+  secretStoreRefName: ""
+  secretStoreRefKind: ClusterSecretStore  # or SecretStore
+  refreshInterval: 1h
+  path: ""  # Vault key path, e.g. "canvas-bridge/staging"
+  properties:
+    sessionSecret: session-secret
+    samlSpCert: saml-sp-cert
+    samlSpKey: saml-sp-key
+    samlIdpCert: saml-idp-cert
+
+# Cleanup CronJob — runs python -m app.cleanup to delete sessions older than
+# retentionHours. Mounts the uploads PVC.
+cleanup:
+  enabled: true
+  schedule: "0 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 1
+  resources: {}
+
+nodeSelector: {}
+tolerations: []
+affinity: {}

--- a/canvas-bridge/values.yaml
+++ b/canvas-bridge/values.yaml
@@ -19,6 +19,7 @@ service:
 ingress:
   enabled: true
   class: nginx
+  tls: true
   annotations:
     kubernetes.io/tls-acme: "true"
     # Allow large zip uploads through to tusd (up to its --max-size limit).

--- a/canvas-bridge/values.yaml
+++ b/canvas-bridge/values.yaml
@@ -37,6 +37,8 @@ app:
   retentionHours: 24
   # Defaults to baseUrl when empty.
   samlEntityId: ""
+  samlAcsPath: /auth/saml/callback
+  samlSloPath: /auth/logout
   resources: {}
 
 # tusd sidecar (resumable uploads on port 8080)


### PR DESCRIPTION
Introduce a new Helm chart for the canvas-bridge FastAPI service. Adds Chart.yaml and .helmignore, templates (helpers, validation guards, Deployment with FastAPI + tusd sidecar, Service, Ingress, PVCs, ExternalSecret, and cleanup CronJob), and a comprehensive values.yaml. The chart wires ExternalSecret for sensitive keys, provides PVCs for uploads and tus staging, ingress rules and TLS support, and validation to ensure required values (app.baseUrl, ingress.host when enabled, and externalSecret settings) are set. Defaults include the container images, csi-rbd persistence settings, and cleanup job configuration.