### PR TITLE
moodle: add feature for postgres metrics exporter

### DIFF
--- a/moodle/Chart.yaml
+++ b/moodle/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: moodle
-version: 0.3.16
+version: 0.3.17
 appVersion: 4.5.8
 description: Moodle is a learning platform designed to provide educators, administrators and learners with a single robust, secure and integrated system to create personalised learning environments
 keywords:

--- a/moodle/templates/postgresql.yaml
+++ b/moodle/templates/postgresql.yaml
@@ -64,4 +64,29 @@ spec:
   {{- with .Values.db.postgres.extraManifest }}
   {{- toYaml . | nindent 2 }}
   {{- end }}
+  {{- if .Values.db.postgres.exporter.enabled }}
+  podAnnotations:
+    {{- toYaml .Values.db.postgres.exporter.podAnnotations | nindent 4 }}
+  sidecars:
+    - name: postgres-exporter
+      image: {{ printf "%s:%s" .Values.db.postgres.exporter.image.repository (required "db.postgres.exporter.image.tag is required when db.postgres.exporter.enabled=true" .Values.db.postgres.exporter.image.tag) | quote }}
+      imagePullPolicy: {{ .Values.db.postgres.exporter.imagePullPolicy | quote }}
+      ports:
+        - name: metrics
+          containerPort: 9187
+      env:
+        - name: DATA_SOURCE_URI
+          value: "localhost:5432/postgres?sslmode=disable"
+        - name: DATA_SOURCE_USER
+          value: postgres
+        - name: DATA_SOURCE_PASS
+          valueFrom:
+            secretKeyRef:
+              name: {{ printf "postgres.%s.credentials.postgresql.acid.zalan.do" (include "moodle.postgresClusterName" .) | quote }}
+              key: password
+      {{- with .Values.db.postgres.exporter.resources }}
+      resources:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  {{- end }}
 {{- end -}}

--- a/moodle/values.yaml
+++ b/moodle/values.yaml
@@ -188,6 +188,23 @@ db:
       ## to spilo/WAL-G). Despite the legacy name, this is a count, not a duration.
       ## With one full backup per day, 7 ≈ one week of retention.
       retentionCount: 7
+    ## Prometheus postgres-exporter sidecar injected into each postgres pod
+    ## via the operator's sidecars field. Connects to localhost so no extra
+    ## network policy is needed. Authenticates as the operator-managed
+    ## `postgres` superuser (secret auto-created by the operator).
+    exporter:
+      enabled: false
+      image:
+        repository: prometheuscommunity/postgres-exporter
+        tag: ""  # required — set explicitly in each env's values file
+      imagePullPolicy: IfNotPresent
+      resources:
+        requests:
+          memory: 64Mi
+          cpu: 50m
+      podAnnotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9187"
     ## Deep-merged into the rendered CR's spec: for fields not surfaced above.
     extraManifest: {}
 


### PR DESCRIPTION
Previewing the manifest diff with this chart gives this:

(todo: edit to use `quay.io` as the registry)

<img width="735" height="478" alt="Screenshot 2026-05-20 at 4 49 58 PM" src="https://github.com/user-attachments/assets/1a960ec9-090d-473c-b208-061d7f441541" />

