### PR TITLE
feat(mariadb): optional dynamically-provisioned PVC for logical backups

### DIFF
--- a/mariadb/Chart.yaml
+++ b/mariadb/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: mariadb
 description: A Helm chart for MariaDB
 type: application
-version: 0.1.25
+version: 0.1.26
 appVersion: "10.6"

--- a/mariadb/templates/backup-pvc.yaml
+++ b/mariadb/templates/backup-pvc.yaml
@@ -1,0 +1,23 @@
+{{- if and .Values.backup.enabled (eq .Values.backup.type "logical") .Values.backup.pvc.enabled }}
+# Dynamically-provisioned PVC for logical backups. When backup.pvc.enabled is set, the
+# Backup mounts this claim (see backup.yaml storage block) instead of a static volume, so a
+# dynamic provisioner (e.g. nfs-subdir-external-provisioner) auto-creates the backing
+# directory — no manual mkdir on the NFS server per instance.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "mariadb.fullname" . }}-backup-storage
+  labels:
+    {{- include "mariadb.labels" . | nindent 4 }}
+  {{- with .Values.backup.pvc.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  storageClassName: {{ .Values.backup.pvc.storageClassName | quote }}
+  accessModes:
+    {{- toYaml .Values.backup.pvc.accessModes | nindent 4 }}
+  resources:
+    requests:
+      storage: {{ .Values.backup.pvc.size | quote }}
+{{- end }}

--- a/mariadb/templates/backup.yaml
+++ b/mariadb/templates/backup.yaml
@@ -31,7 +31,13 @@ spec:
   serviceAccountName: {{ include "mariadb.fullname" . }}-backup
   compression: {{ .Values.backup.compression }}
   storage:
+    {{- if .Values.backup.pvc.enabled }}
+    volume:
+      persistentVolumeClaim:
+        claimName: {{ include "mariadb.fullname" . }}-backup-storage
+    {{- else }}
     {{- toYaml .Values.backup.storage | nindent 4 }}
+    {{- end }}
   {{- if .Values.backup.stagingStorage.enabled }}
   stagingStore:
     {{- omit .Values.backup.stagingStorage "enabled" | toYaml | nindent 4 }}

--- a/mariadb/values.yaml
+++ b/mariadb/values.yaml
@@ -117,7 +117,19 @@ backup:
     # PodAffinity specifies whether the backup pod should be scheduled on the same node as the MariaDB instance.
     podAffinity: true
   compression: bzip2
-  # Storage for backups
+  # Dynamically-provisioned PVC for backup storage. When enabled, the chart creates a PVC
+  # (<fullname>-backup-storage) and the Backup mounts it via storage.volume.persistentVolumeClaim,
+  # so a dynamic provisioner (e.g. nfs-subdir-external-provisioner) auto-creates the backing
+  # directory — no manual mkdir on the NFS server per instance. Overrides `storage` when enabled.
+  pvc:
+    enabled: false
+    storageClassName: ""
+    accessModes:
+      - ReadWriteMany
+    size: 5Gi
+    # PVC annotations, e.g. nfs.io/storage-path for the nfs-subdir-external-provisioner.
+    annotations: {}
+  # Storage for backups (used only when pvc.enabled is false)
   storage: {}
     # Using PVC for storage
 #    persistentVolumeClaim:


### PR DESCRIPTION
## What

Adds an optional `backup.pvc` block to the mariadb chart. When `backup.pvc.enabled: true`, the chart creates a `<fullname>-backup-storage` PVC and wires the `Backup` to mount it via `storage.volume.persistentVolumeClaim.claimName`. This lets a dynamic provisioner (e.g. `nfs-subdir-external-provisioner`) **auto-create the backing directory**, removing the manual per-instance `mkdir` (owned `999:999`) on the NFS server that backups currently require.

## Why

New instances using the static `storage.volume.nfs` mount silently fail their first backup (`Init:0/1`, `mount.nfs: access denied by server`) because the target subdir doesn't exist and nothing creates it — the app/DB come up green regardless, so it's invisible until the daily cron. A chart-created PVC + provisioner closes that gap. The PVC carries `nfs.io/storage-path` so paths stay human-readable (`hotcrp/<env>`) and existing on-disk dirs are adopted idempotently.

## Backward compatibility

`backup.pvc.enabled` defaults to **false**. Verified via `helm template` that with it off, the rendered `Backup.spec.storage` is unchanged (static `volume.nfs`/`s3` pass-through), and no PVC is created. Existing instances are unaffected.

## Validation

- `helm template` with `backup.pvc.enabled=true`: renders the PVC (storageClassName, `nfs.io/storage-path` annotation, accessModes, size) **and** the Backup `claimName` auto-matching it.
- `helm template` with it disabled: static `volume.nfs` preserved; zero PVCs.
- Provisioner side validated out-of-band: an `nfs-archive` StorageClass (nfs-subdir → `archivep02:/archives`) provisions `/archives/hotcrp/...` and a UID-999 pod writes successfully.

## Follow-up (separate PR, ordered)

hotcrp vendors mariadb via `Chart.lock`, so after this publishes `mariadb-0.1.26`: run `helm dependency update ./hotcrp`, bump hotcrp `0.3.9 → 0.3.10`, then a `configuration` change switches **hotcrp-test** (canary) to `backup.pvc` on `nfs-archive` before rolling out the rest.

Bumps chart `0.1.25 → 0.1.26`.