### PR TITLE
chore(hotcrp): bump 0.3.10, re-vendor mariadb 0.1.26 (backup PVC support)

### DIFF
--- a/hotcrp/Chart.lock
+++ b/hotcrp/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
   repository: https://ubc.github.io/charts
-  version: 0.1.17
-digest: sha256:5d4a8fd1eb953edbf79518cc212ac659fe5ae06e426e654e90f6818b0e16316d
-generated: "2026-03-12T01:33:15.881021-07:00"
+  version: 0.1.26
+digest: sha256:4d0a30292e71a2cb0a5cb60b9b3600c2cc72b0ec1f5d64217ba0a0463f398ce7
+generated: "2026-06-21T17:29:50.417053-07:00"

--- a/hotcrp/Chart.yaml
+++ b/hotcrp/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.9
+version: 0.3.10
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to


### PR DESCRIPTION
Follow-up to #62 (now merged, `mariadb-0.1.26` published).

## What
- Bumps hotcrp `0.3.9 → 0.3.10`.
- Refreshes `Chart.lock` `mariadb 0.1.17 → 0.1.26` via `helm dependency update`, so the packaged hotcrp chart includes the mariadb that exposes `backup.pvc` (dynamically-provisioned backup storage).

## Why
Lets hotcrp instances switch their DB backup off the static `archivep02` NFS mount (which needs a manual root `mkdir` of `/archives/hotcrp/<env>` per instance, owned `999:999`, or the first backup hangs `Init:0/1` with `access denied by server`) to a `nfs-archive` provisioner-backed PVC that auto-creates the dir.

No hotcrp template changes — purely opt-in per instance via `db.backup.pvc.*` in the `configuration` values.

## Rollout after merge
1. `configuration`: switch **hotcrp-test** (canary) to `db.backup.pvc` on `nfs-archive`, bump its appset revision `0.3.7 → 0.3.10`; verify a backup lands in `/archives/hotcrp/test`.
2. Roll the remaining instances over and drop the static mounts.