### PR TITLE
feat(mariadb): Force+Replace sync-option on Backup for PVC migration

### DIFF
--- a/mariadb/Chart.yaml
+++ b/mariadb/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: mariadb
 description: A Helm chart for MariaDB
 type: application
-version: 0.1.26
+version: 0.1.27
 appVersion: "10.6"

--- a/mariadb/templates/backup.yaml
+++ b/mariadb/templates/backup.yaml
@@ -3,6 +3,14 @@ apiVersion: k8s.mariadb.com/v1alpha1
 kind: Backup
 metadata:
   name: {{ include "mariadb.fullname" . }}-backup
+  {{- if .Values.backup.pvc.enabled }}
+  annotations:
+    # spec.storage is immutable (mariadb-operator vbackup webhook). When switching to /
+    # using a PVC, a plain ArgoCD apply fails with "field is immutable"; Force+Replace
+    # makes ArgoCD delete+recreate the Backup so the storage change lands (brief schedule
+    # gap only; backup files on the volume are untouched).
+    argocd.argoproj.io/sync-options: Force=true,Replace=true
+  {{- end }}
 spec:
   mariaDbRef:
     name: {{ include "mariadb.fullname" . }}


### PR DESCRIPTION
Phase 2 enabler for the hotcrp backup-storage migration (follows #62, #63).

## Problem
`Backup.spec.storage` is **immutable** (operator `vbackup` webhook). Flipping an existing instance's backup from the static `volume.nfs` mount to a PVC fails the ArgoCD sync with `spec.storage: field is immutable` — verified on the hotcrp-test canary, which required a manual `kubectl delete backup` + re-sync.

## Change
When `backup.pvc.enabled`, annotate the `Backup` with:
```yaml
argocd.argoproj.io/sync-options: Force=true,Replace=true
```
so ArgoCD delete+recreates the Backup (only `Force=true,Replace=true` clears immutable-field errors; `Replace=true` alone does not). This lets the remaining ~15 hotcrp instances migrate to `nfs-archive` PVC backups via **pure git changes** — no manual Backup deletion each.

Annotation is gated on `backup.pvc.enabled`, so static-mount instances are unaffected (verified via `helm template`: present when pvc on, absent when off). Brief schedule gap on recreate only; backup files on the volume are untouched.

Bumps `0.1.26 → 0.1.27`.

## Follow-up
After publish: bump hotcrp `0.3.10 → 0.3.11` (re-vendor 0.1.27), then roll the 15 instances (values `db.backup.pvc` + appset `→0.3.11`). First instance doubles as the Force+Replace validation.