### PR TITLE
chore(hotcrp): bump 0.3.11, re-vendor mariadb 0.1.27 (Backup Force+Replace)

### DIFF
--- a/hotcrp/Chart.lock
+++ b/hotcrp/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
   repository: https://ubc.github.io/charts
-  version: 0.1.26
-digest: sha256:4d0a30292e71a2cb0a5cb60b9b3600c2cc72b0ec1f5d64217ba0a0463f398ce7
-generated: "2026-06-21T17:29:50.417053-07:00"
+  version: 0.1.27
+digest: sha256:bb942f30ea36d1c61d20f82af2288752d7bd4b33909d9bf6bd1ff2d489b75073
+generated: "2026-06-22T13:31:52.394936-07:00"

--- a/hotcrp/Chart.yaml
+++ b/hotcrp/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.10
+version: 0.3.11
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to


### PR DESCRIPTION
Follow-up to #64 (`mariadb-0.1.27` published).

- Bumps hotcrp `0.3.10 → 0.3.11`.
- Refreshes `Chart.lock` `mariadb 0.1.26 → 0.1.27` so the packaged chart includes the `Force=true,Replace=true` sync-option that the mariadb Backup gets when `backup.pvc.enabled`.

## Why
`Backup.spec.storage` is immutable; without this, migrating an instance static→PVC needs a manual `kubectl delete backup` + re-sync (as the hotcrp-test canary did). With 0.3.11, ArgoCD delete+recreates the Backup itself, so the remaining ~15 instances migrate via pure git.

## Rollout after merge
`configuration`: per instance set `db.backup.pvc` (on `nfs-archive`, `nfs.io/storage-path: hotcrp/<env>`) + bump appset revision `→ 0.3.11`. Do one instance first as a live Force+Replace checkpoint, then the rest.