### PR TITLE
feat(webwork): Fluent Bit log-shipping sidecar (0.2.7)

### DIFF
--- a/webwork/Chart.yaml
+++ b/webwork/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.6
+version: 0.2.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/webwork/templates/_helpers.tpl
+++ b/webwork/templates/_helpers.tpl
@@ -297,6 +297,9 @@ volumeMounts:
 {{- if .Values.logsPersistence.enabled }}
   persistentVolumeClaim:
     claimName: {{ template "webwork.fullname" . }}-logs-pvc
+{{- else if .Values.logShipping.enabled }}
+  emptyDir:
+    sizeLimit: {{ .Values.logShipping.emptyDirSizeLimit }}
 {{- else }}
   emptyDir: {}
 {{- end }}
@@ -323,8 +326,90 @@ volumeMounts:
     - key: authen_saml2
       path: authen_saml2.yml
 {{- end }}
+{{- if .Values.logShipping.enabled }}
+{{- include "webwork.logShipper.volumes" . | nindent 0 }}
+{{- end }}
 
 {{- end }}
+
+{{/*
+Log-shipping native sidecars.
+
+Rendered into each workload's `initContainers:` as native sidecars
+(restartPolicy: Always) — they start before the app and keep running, but
+terminate when the main container exits, so cronjob Jobs still complete. Gated by
+the caller on .Values.logShipping.enabled.
+
+  - log-shipper: Fluent Bit tails /opt/webwork/webwork2/logs/*.log (read-only)
+    and HTTP-POSTs to the on-prem relay (basicAuth from the synced secret).
+  - log-rotate (optional): truncates any *.log over maxBytes; truncate-in-place is
+    safe with WeBWorK's O_APPEND writers and Fluent Bit tail (which re-reads from 0).
+*/}}
+{{- define "webwork.logShipper.initContainers" -}}
+- name: log-shipper
+  image: "{{ .Values.logShipping.image.repository }}:{{ .Values.logShipping.image.tag }}"
+  imagePullPolicy: {{ .Values.logShipping.image.pullPolicy }}
+  restartPolicy: Always
+  args: ["-c", "/fluent-bit/etc/fluent-bit.conf"]
+  env:
+    - name: LOGRELAY_USER
+      valueFrom:
+        secretKeyRef:
+          name: {{ .Values.logShipping.auth.secretName }}
+          key: username
+    - name: LOGRELAY_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: {{ .Values.logShipping.auth.secretName }}
+          key: password
+  volumeMounts:
+    - name: webwork-logs-data
+      mountPath: /opt/webwork/webwork2/logs
+      readOnly: true
+    - name: log-shipper-config
+      mountPath: /fluent-bit/etc
+    - name: log-shipper-buffer
+      mountPath: /var/log/fluent-bit
+  resources:
+    {{- toYaml .Values.logShipping.resources | nindent 4 }}
+{{- if .Values.logShipping.rotation.enabled }}
+- name: log-rotate
+  image: "{{ .Values.logShipping.rotation.image.repository }}:{{ .Values.logShipping.rotation.image.tag }}"
+  imagePullPolicy: {{ .Values.logShipping.rotation.image.pullPolicy }}
+  restartPolicy: Always
+  command:
+    - /bin/sh
+    - -c
+    - |
+      MAX={{ .Values.logShipping.rotation.maxBytes }}
+      while true; do
+        for f in /opt/webwork/webwork2/logs/*.log; do
+          [ -f "$f" ] || continue
+          sz=$(wc -c < "$f" 2>/dev/null || echo 0)
+          [ "$sz" -gt "$MAX" ] && : > "$f"
+        done
+        sleep {{ .Values.logShipping.rotation.intervalSeconds }}
+      done
+  volumeMounts:
+    - name: webwork-logs-data
+      mountPath: /opt/webwork/webwork2/logs
+  resources:
+    requests: { cpu: 10m, memory: 16Mi }
+    limits:   { cpu: 50m, memory: 32Mi }
+{{- end }}
+{{- end -}}
+
+{{/*
+Extra volumes for the log-shipping sidecars (Fluent Bit config + buffer).
+Appended to the workload `volumes:` via webwork.app.mounts when logShipping is on.
+*/}}
+{{- define "webwork.logShipper.volumes" -}}
+- name: log-shipper-config
+  configMap:
+    name: {{ include "webwork.fullname" . }}-fluent-bit
+- name: log-shipper-buffer
+  emptyDir: {}
+{{- end -}}
 
 {{/*
 Resolve the effective database provider.

--- a/webwork/templates/cronjob.yaml
+++ b/webwork/templates/cronjob.yaml
@@ -17,6 +17,10 @@ spec:
       template:
         spec:
           restartPolicy: {{ .Values.cronjob.lti_update_classlist.restartPolicy }}
+          {{- if .Values.logShipping.enabled }}
+          initContainers:
+            {{- include "webwork.logShipper.initContainers" . | nindent 10 }}
+          {{- end }}
           containers:
           - name: {{ .Chart.Name }}-classlist-cronjob
             {{- include "webwork.app.spec" . | indent 12 }}
@@ -45,6 +49,10 @@ spec:
       template:
         spec:
           restartPolicy: {{ .Values.cronjob.lti_update_grades.restartPolicy }}
+          {{- if .Values.logShipping.enabled }}
+          initContainers:
+            {{- include "webwork.logShipper.initContainers" . | nindent 10 }}
+          {{- end }}
           containers:
           - name: {{ .Chart.Name }}-grades-cronjob
             {{- include "webwork.app.spec" . | indent 12 }}

--- a/webwork/templates/deployment.yaml
+++ b/webwork/templates/deployment.yaml
@@ -40,6 +40,10 @@ spec:
       serviceAccountName: {{ include "webwork.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if .Values.logShipping.enabled }}
+      initContainers:
+        {{- include "webwork.logShipper.initContainers" . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           {{- include "webwork.app.spec" . | indent 10 }}
@@ -114,6 +118,10 @@ spec:
       serviceAccountName: {{ include "webwork.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if .Values.logShipping.enabled }}
+      initContainers:
+        {{- include "webwork.logShipper.initContainers" . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}-worker-lti1p3
           {{- include "webwork.app.spec" . | indent 10 }}
@@ -169,6 +177,10 @@ spec:
       serviceAccountName: {{ include "webwork.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if .Values.logShipping.enabled }}
+      initContainers:
+        {{- include "webwork.logShipper.initContainers" . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}-worker-mojo
           {{- include "webwork.app.spec" . | indent 10 }}

--- a/webwork/templates/external-secret-logshipper.yaml
+++ b/webwork/templates/external-secret-logshipper.yaml
@@ -1,0 +1,29 @@
+{{- if and .Values.logShipping.enabled .Values.logShipping.auth.externalSecret.enabled }}
+# basicAuth creds for the log-shipping sidecar -> on-prem relay ingress.
+# Synced from Vault by ESO. NOTE: the vault-backend store has path=secret, so the
+# remoteRef key is RELATIVE (logging/webwork-log-relay, not secret/logging/...).
+# The on-prem Traefik reads the matching `htpasswd` from the same Vault path.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ .Values.logShipping.auth.secretName }}
+  labels:
+    {{- include "webwork.labels" . | nindent 4 }}
+    tier: logshipper
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: {{ .Values.logShipping.auth.externalSecret.secretStoreRef }}
+    kind: ClusterSecretStore
+  target:
+    name: {{ .Values.logShipping.auth.secretName }}
+  data:
+    - secretKey: username
+      remoteRef:
+        key: {{ .Values.logShipping.auth.externalSecret.vaultKey }}
+        property: username
+    - secretKey: password
+      remoteRef:
+        key: {{ .Values.logShipping.auth.externalSecret.vaultKey }}
+        property: password
+{{- end }}

--- a/webwork/templates/fluent-bit-configmap.yaml
+++ b/webwork/templates/fluent-bit-configmap.yaml
@@ -1,0 +1,92 @@
+{{- if .Values.logShipping.enabled }}
+# Fluent Bit config for the per-pod log-shipping sidecar. Tails the WeBWorK system
+# logs (now a per-pod emptyDir, not shared EFS) and HTTP-POSTs them to the on-prem
+# relay (logging/webwork-log-relay), which fans out to ECK + the archive server.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "webwork.fullname" . }}-fluent-bit
+  labels:
+    {{- include "webwork.labels" . | nindent 4 }}
+    tier: logshipper
+data:
+  fluent-bit.conf: |
+    [SERVICE]
+        Flush                     5
+        Daemon                    Off
+        Log_Level                 info
+        Parsers_File              parsers.conf
+        HTTP_Server               On
+        HTTP_Listen               0.0.0.0
+        HTTP_Port                 2020
+        storage.path              /var/log/fluent-bit/
+        storage.sync              normal
+        storage.backlog.mem_limit 32M
+
+    [INPUT]
+        Name              tail
+        Path              /opt/webwork/webwork2/logs/*.log
+        Path_Key          source_file
+        Tag               webwork.prod
+        DB                /var/log/fluent-bit/tail.db
+        multiline.parser  webwork_ml
+        Skip_Long_Lines   On
+        Refresh_Interval  5
+        Rotate_Wait       5
+        storage.type      filesystem
+
+    # Derive a `log_type` field from the source filename (strips the monthly
+    # _YYYY_MM suffix and collapses per-course transaction/batch logs).
+    [FILTER]
+        Name    lua
+        Match   webwork.*
+        script  log_type.lua
+        call    set_log_type
+
+    [FILTER]
+        Name    modify
+        Match   webwork.*
+        Add     cluster   {{ .Values.logShipping.labels.cluster }}
+        Add     service   {{ .Values.logShipping.labels.service }}
+        Add     namespace {{ .Release.Namespace }}
+
+    [OUTPUT]
+        Name        http
+        Match       webwork.*
+        Host        {{ .Values.logShipping.endpoint.host }}
+        Port        {{ .Values.logShipping.endpoint.port }}
+        URI         {{ .Values.logShipping.endpoint.uri }}
+        tls         {{ if .Values.logShipping.endpoint.tls }}On{{ else }}Off{{ end }}
+        tls.verify  On
+        HTTP_User   ${LOGRELAY_USER}
+        HTTP_Passwd ${LOGRELAY_PASSWORD}
+        Format      json
+        Json_Date_Key   @timestamp
+        Json_Date_Format iso8601
+        Retry_Limit False
+        storage.total_limit_size 2G
+
+  parsers.conf: |
+    # A WeBWorK log entry starts with a bracketed timestamp; continuation lines
+    # (e.g. multi-line Perl error dumps in webwork2.log) do not. Group them.
+    #   [Mon Jun 29 13:55:19.671786 2026] ...
+    #   [2026-06-29 17:34:07.93515] ...
+    [MULTILINE_PARSER]
+        Name          webwork_ml
+        Type          regex
+        Flush_Timeout 1000
+        Rule          "start_state"  "/^\[.*/"     "cont"
+        Rule          "cont"         "/^[^\[].*/"  "cont"
+
+  log_type.lua: |
+    function set_log_type(tag, ts, record)
+      local src = record["source_file"]
+      if src == nil then return 0, ts, record end
+      local base = string.match(src, "([^/]+)%.log$") or src
+      base = string.gsub(base, "_%d%d%d%d_%d%d$", "")   -- strip monthly suffix
+      if string.match(base, "_transaction$")    then base = "transaction"   end
+      if string.match(base, "_batch_grading$")  then base = "batch_grading" end
+      record["log_type"] = base
+      return 2, ts, record
+    end
+{{- end }}

--- a/webwork/values.yaml
+++ b/webwork/values.yaml
@@ -124,6 +124,61 @@ logsPersistence:
   accessMode: ReadWriteMany
   size: 8Gi
 
+# Ship /opt/webwork/webwork2/logs off-cluster instead of (or in addition to)
+# keeping them on a shared volume. A Fluent Bit *native* sidecar (initContainer +
+# restartPolicy: Always, so cronjob Jobs still complete) tails the log files and
+# HTTP-POSTs them to an on-prem fluentd relay, which fans out to Elasticsearch +
+# an archive server.
+#
+# Typically paired with `logsPersistence.enabled: false` so the logs live on a
+# per-pod emptyDir (no shared EFS RWX, no multi-writer interleaving) — but it also
+# works with the PVC still enabled (useful as a no-data-loss intermediate step
+# during cutover). When enabled and logsPersistence is false, set the rotation
+# guard so the unbounded files (timing.log, webwork2.log) can't fill node disk.
+logShipping:
+  enabled: false
+  image:
+    repository: cr.fluentbit.io/fluent/fluent-bit
+    tag: "3.2.10"
+    pullPolicy: IfNotPresent
+  # Where the on-prem relay ingress lives. The path segment becomes the fluentd
+  # tag (must start with "webwork." to match the relay's <match webwork.**>).
+  endpoint:
+    host: logs-ingest.ctlt.ubc.ca
+    port: 443
+    tls: true
+    uri: /webwork.prod
+  # Labels stamped onto every shipped record (used as ES fields / for filtering).
+  labels:
+    cluster: appcloud-prod
+    service: webwork
+  # basicAuth for the relay ingress. With externalSecret.enabled the username/
+  # password are synced from Vault (secret/logging/webwork-log-relay) by ESO into
+  # `secretName`; otherwise reference an existing Secret with username/password keys.
+  auth:
+    externalSecret:
+      enabled: true
+      secretStoreRef: vault-backend
+      # key is relative to the vault-backend store (path=secret) -> secret/webwork/prod/logging-relay
+      vaultKey: webwork/prod/logging-relay
+    secretName: webwork-log-relay-auth
+  resources:
+    requests: { cpu: 50m, memory: 64Mi }
+    limits:   { cpu: 200m, memory: 192Mi }
+  # Copytruncate guard for the unbounded logs when on emptyDir. A tiny busybox
+  # native sidecar truncates any *.log over maxBytes every intervalSeconds.
+  # Truncate-in-place is safe with WeBWorK's O_APPEND writers and Fluent Bit tail.
+  rotation:
+    enabled: true
+    maxBytes: 209715200        # 200Mi per file
+    intervalSeconds: 600
+    image:
+      repository: busybox
+      tag: "1.37"
+      pullPolicy: IfNotPresent
+  # sizeLimit for the logs emptyDir (only applied when logsPersistence is off).
+  emptyDirSizeLimit: 4Gi
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true


### PR DESCRIPTION
Optional `logShipping`: a Fluent Bit **native sidecar** (initContainer + `restartPolicy: Always`, so cronjob Jobs still complete) plus a busybox copytruncate rotator tails `/opt/webwork/webwork2/logs` and HTTP-POSTs to the on-prem relay — letting prod drop the logs EFS PVC and removing the per-log-entry open/flock/append/close NFS churn + cross-pod lock contention on the shared files.

- Tags by `log_type`, basic-auth from Vault `secret/webwork/prod/logging-relay` via ESO.
- Added to web + both workers + both cronjobs (not r/shibd — they don't mount logs).
- **Default-off**, so staging/dev are unaffected; pair with `logsPersistence.enabled: false`.
- `helm template`/`helm lint` clean; renders 5 native sidecars.

Pairs with the k8s-config relay MR and the devops/configuration prod-values MR.

https://claude.ai/code/session_01RhcW8a2U1FqWq7k1eBuFkA